### PR TITLE
add blackfill option for settings

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -6,5 +6,11 @@ database_url = "postgresql://etlite:password@127.0.0.1/helium_lite"
 #								 listed below in filters
 mode = "rewards"
 
+
+# "true" or "false" 
+# If set to "true", scan the node for the oldest block it has and start loading transactions from there. 
+# If set to "false", start loading blocks starting at the current height of the node.
+backfill = "false"
+
 [log]
 log_dir = "log"

--- a/src/follower.rs
+++ b/src/follower.rs
@@ -25,10 +25,14 @@ impl Follower {
 		let info = match load_follower_info(&logger, &pgclient).await {
 			Ok(i) => i,
 			Err(_) => {
-				let first = get_first_block(&client, &logger, shutdown.clone()).await.unwrap();
+				let first = match settings.backfill {
+					true => get_first_block(&client, &logger, shutdown.clone()).await.unwrap(),
+					false => blocks::height(&client).await?
+				};
+				
 				create_follower_info(&logger, &pgclient, first).await.unwrap();
 				Info {
-					height: first,
+					height: first-1,
 					first_block: first,
 				}				
 			}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -43,6 +43,9 @@ pub struct Settings {
 	#[serde(deserialize_with = "deserialize_etl_mode")]
 	pub mode: EtlMode,
 
+	#[serde(deserialize_with = "deserialize_backfill")]	
+	pub backfill: bool,
+
 }
 
 impl Settings {
@@ -80,4 +83,21 @@ where
         }
     };
     Ok(mode)
+}
+
+fn deserialize_backfill<'de, D>(d: D) -> std::result::Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let backfill = match String::deserialize(d)?.to_lowercase().as_str() {
+        "true" => true,
+        "false" => false,
+        unsupported => {
+            return Err(de::Error::custom(format!(
+                "unsupported etl mode: \"{}\"",
+                unsupported
+            )))
+        }
+    };
+    Ok(backfill)
 }


### PR DESCRIPTION
adds the ability to not 'backfill' to nodes oldest block. This will save time if node has been running for a long time and has a really old first block, but you don't need all that old history loaded for your etl