### PR TITLE
Support for Full mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,7 @@ slog-term = "2.6"
 triggered = "0.1"
 refinery = { version = "0.5.0", features = ["tokio-postgres"] }
 structopt = "0.3.22"
-tokio-postgres = { version = "0.7.2" }
+tokio-postgres = { version = "0.7.2", features = ["with-serde_json-1"] }
+postgres-types = "0.2.2"
+
 url = "2.2.2"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Settings are found in the `settings.toml` file in the `config` directory.
 `database_url` : Url to postgresql server. 
 
 ## Mode Options
-ETL Lite is currently in `Phase 1` 
+ETL Lite is currently in `Phase 2`
+*For Full mode: state_channel_close_v1 transactions are currently not supported due to [this](https://github.com/dewi-alliance/helium-jsonrpc-rs/issues/8) issue. 
 
 | Phase     | Modes Available				 |
 | --------- | ---------------------- |

--- a/src/follower.rs
+++ b/src/follower.rs
@@ -138,8 +138,6 @@ impl Follower {
 		},
 			_ => (),
 		}
-		info!(logger, "Done!");
-		panic!("done");
 	}
 
 	pub async fn update_follower_info_first_block(&self) -> Result<Vec<tokio_postgres::Row>>{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod settings;
 pub mod follower;
 pub mod migrate;
 pub mod reward;
+pub mod transaction;
 
 pub use error::{Error, Result};
 pub use settings::{EtlMode, Settings};

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -72,6 +72,7 @@ where
     let mode = match String::deserialize(d)?.to_lowercase().as_str() {
         "rewards" => EtlMode::Rewards,
         "challenges" => EtlMode::Challenges,
+        "full" => EtlMode::Full,
         unsupported => {
             return Err(de::Error::custom(format!(
                 "unsupported etl mode: \"{}\"",

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,34 @@
+use crate::*;
+use tokio_postgres::{Client, Statement};
+use std::convert::TryFrom;
+use helium_jsonrpc::Transaction;
+use tokio_postgres::types::{Json};
+
+pub async fn prepare(client: &Client) -> Result<Statement>{
+	let stmt = client.prepare(r#"INSERT INTO transactions (block, hash, type, fields) 
+		VALUES ($1, $2, CAST(CAST($3 AS VARCHAR) AS "transaction_type"), $4)"#).await;
+	match stmt {
+		Ok(s) => Ok(s),
+		Err(e) => Err(error::Error::PgError(e)),
+	}
+}
+
+pub async fn add_transaction(client:  &Client, 
+	block: u64, 
+	hash: String, 
+	r#type: &str, 
+	transaction: Transaction) -> Result<Vec<tokio_postgres::Row>> {
+	let stmt = prepare(&client).await.unwrap();
+	let fields = Json(transaction);
+
+	match client.query(&stmt, &[&i64::try_from(block).unwrap(),
+		&hash,
+		&r#type,
+		&fields]).await {
+		Ok(v) => Ok(v),
+		Err(e) => {
+			println!("{}", e);
+			Err(error::Error::PgError(e))
+		},
+	}
+}


### PR DESCRIPTION
adds migration to create 'transactions' table
'full' mode supported to load all transactions via jsonb

todo: state_channel_close_v1 transactions currently not supported due to: https://github.com/dewi-alliance/helium-jsonrpc-rs/issues/8