### PR TITLE
better error handling in block_processor

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
   PgError(#[from] tokio_postgres::Error), 
   #[error("config error")]
   Config(#[from] config::ConfigError),
-  #[error("custom error")]
+  #[error("custom error: {}", .0)]
   Custom(String),
   #[error("helium_jsonrpc error")]
   JrpcError(#[from] helium_jsonrpc::Error),


### PR DESCRIPTION
This makes sure that in case of a transient error, `load_block` returns an error, instead of printing the error and moving to the next reward/transaction